### PR TITLE
resolve pylint conventions and warnings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,9 @@
 
 # Note: To use the 'upload' functionality of this file, you must:
 #   $ pipenv install twine --dev
+"""
+setup.py for human
+"""
 
 import io
 import os
@@ -33,26 +36,26 @@ EXTRAS = {
 # The rest you shouldn't have to touch too much :)
 # ------------------------------------------------
 # Except, perhaps the License and Trove Classifiers!
-# If you do change the License, remember to change the Trove Classifier for that!
+# If you change the License, remember to change the Trove Classifier for that!
 
-here = os.path.abspath(os.path.dirname(__file__))
+HERE = os.path.abspath(os.path.dirname(__file__))
 
 # Import the README and use it as the long-description.
 # Note: this will only work if 'README.md' is present in your MANIFEST.in file!
 try:
-    with io.open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
-        long_description = '\n' + f.read()
+    with io.open(os.path.join(HERE, 'README.md'), encoding='utf-8') as f:
+        LONG_DESCRIPTION = '\n' + f.read()
 except FileNotFoundError:
-    long_description = DESCRIPTION
+    LONG_DESCRIPTION = DESCRIPTION
 
 # Load the package's __version__.py module as a dictionary.
-about = {}
+ABOUT = {}
 if not VERSION:
-    project_slug = NAME.lower().replace("-", "_").replace(" ", "_")
-    with open(os.path.join(here, project_slug, '__version__.py')) as f:
-        exec(f.read(), about)
+    PROJECT_SLUG = NAME.lower().replace("-", "_").replace(" ", "_")
+    with open(os.path.join(HERE, PROJECT_SLUG, '__version__.py')) as f:
+        exec(f.read(), ABOUT)  # pylint: disable=W0122
 else:
-    about['__version__'] = VERSION
+    ABOUT['__version__'] = VERSION
 
 
 class UploadCommand(Command):
@@ -62,31 +65,34 @@ class UploadCommand(Command):
     user_options = []
 
     @staticmethod
-    def status(s):
+    def status(stat):
         """Prints things in bold."""
-        print('\033[1m{0}\033[0m'.format(s))
+        print('\033[1m{0}\033[0m'.format(stat))
 
     def initialize_options(self):
-        pass
+        """Initialize Options"""
 
     def finalize_options(self):
-        pass
+        """Finalize Options"""
 
     def run(self):
+        """Cleanup, build, upload, and git tag"""
         try:
             self.status('Removing previous builds…')
-            rmtree(os.path.join(here, 'dist'))
+            rmtree(os.path.join(HERE, 'dist'))
         except OSError:
             pass
 
         self.status('Building Source and Wheel (universal) distribution…')
-        os.system('{0} setup.py sdist bdist_wheel --universal'.format(sys.executable))
+        os.system(
+            '{0} setup.py sdist bdist_wheel --universal'.format(sys.executable)
+        )
 
         self.status('Uploading the package to PyPI via Twine…')
         os.system('twine upload dist/*')
 
         self.status('Pushing git tags…')
-        os.system('git tag v{0}'.format(about['__version__']))
+        os.system('git tag v{0}'.format(ABOUT['__version__']))
         os.system('git push --tags')
 
         sys.exit()
@@ -95,15 +101,17 @@ class UploadCommand(Command):
 # Where the magic happens:
 setup(
     name=NAME,
-    version=about['__version__'],
+    version=ABOUT['__version__'],
     description=DESCRIPTION,
-    long_description=long_description,
+    long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',
     author=AUTHOR,
     author_email=EMAIL,
     python_requires=REQUIRES_PYTHON,
     url=URL,
-    packages=find_packages(exclude=["tests", "*.tests", "*.tests.*", "tests.*"]),
+    packages=find_packages(
+        exclude=["tests", "*.tests", "*.tests.*", "tests.*"]
+    ),
     # If your package is a single module, use this instead of 'packages':
     # py_modules=['mypackage'],
 


### PR DESCRIPTION
# Update to resolve pylint conventions and a warning
The below is the results of `pylint`, `pycodestyle`, and `flake8`:
```
(setup.py) bash-3.2$ pylint setup.py 
************* Module setup
setup.py:1:0: C0114: Missing module docstring (missing-module-docstring)
setup.py:38:0: C0103: Constant name "here" doesn't conform to UPPER_CASE naming style (invalid-name)
setup.py:44:8: C0103: Constant name "long_description" doesn't conform to UPPER_CASE naming style (invalid-name)
setup.py:46:4: C0103: Constant name "long_description" doesn't conform to UPPER_CASE naming style (invalid-name)
setup.py:49:0: C0103: Constant name "about" doesn't conform to UPPER_CASE naming style (invalid-name)
setup.py:51:4: C0103: Constant name "project_slug" doesn't conform to UPPER_CASE naming style (invalid-name)
setup.py:53:8: W0122: Use of exec (exec-used)
setup.py:65:4: C0103: Argument name "s" doesn't conform to snake_case naming style (invalid-name)
setup.py:69:4: C0116: Missing function or method docstring (missing-function-docstring)
setup.py:72:4: C0116: Missing function or method docstring (missing-function-docstring)
setup.py:75:4: C0116: Missing function or method docstring (missing-function-docstring)

------------------------------------------------------------------
Your code has been rated at 7.80/10 (previous run: 7.80/10, +0.00)

(setup.py) bash-3.2$ pycodestyle setup.py 
setup.py:36:80: E501 line too long (81 > 79 characters)
setup.py:83:80: E501 line too long (86 > 79 characters)
setup.py:106:80: E501 line too long (81 > 79 characters)
(setup.py) bash-3.2$ flake8 setup.py 
setup.py:36:80: E501 line too long (81 > 79 characters)
setup.py:83:80: E501 line too long (86 > 79 characters)
setup.py:106:80: E501 line too long (81 > 79 characters)
(setup.py) bash-3.2$
```
This branch resolves above conventions and a warning as below:
```
(setup.py) bash-3.2$ pylint setup.py 

-------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 7.80/10, +2.20)

(setup.py) bash-3.2$ pycodestyle setup.py 
(setup.py) bash-3.2$ flake8 setup.py 
(setup.py) bash-3.2$
```
